### PR TITLE
Major change to validation, adding ai ignoring cells with sunk ship parts next to them

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -70,6 +70,9 @@ class Game {
                     }
                     this.updateAndRender()
                 },
+                attackMouseOver: () => {
+                    document.getElementById(`${whichBoard}_${i}`).style.cursor = 'crosshair'
+                },
                 deployment: () => {
                     this.addShip(this.shipToPlace.board, this[whichBoard].cells[i].id, this.shipToPlace.type, this.shipToPlace.orientation)
                     this.updateAndRender()
@@ -208,6 +211,7 @@ class Game {
                     break
                 case 'attack':
                     cell.addEventListener("click", this[whichBoard].cells[id].attack)
+                    cell.addEventListener("mouseover", this[whichBoard].cells[id].attackMouseOver)
                     break
                 case 'over':
                     break


### PR DESCRIPTION
It turns out that a set of numbers and a grid are not the same thing. Attempting to access a grid above and to the right of the grid in the right-up corner was previously done by subtracting 9 from the grid's id, which is 9. It was not realized that this resulted in 0, a valid grid id, rather than an invalid grid id. So I added a grid reference system and conversion to and from ids. Still need to add this to the other search profiles (cross, horizontal, vertical) used by the computer when it has target data